### PR TITLE
Fix developer name in appdata

### DIFF
--- a/fix_developer_name.patch
+++ b/fix_developer_name.patch
@@ -1,0 +1,12 @@
+diff --git a/data/xyz.tytanium.DoorKnocker.appdata.xml.in.in b/data/xyz.tytanium.DoorKnocker.appdata.xml.in.in
+index b49acca..b4c0295 100644
+--- a/data/xyz.tytanium.DoorKnocker.appdata.xml.in.in
++++ b/data/xyz.tytanium.DoorKnocker.appdata.xml.in.in
+@@ -24,6 +24,7 @@ SPDX-License-Identifier: CC0-1.0
+   <developer id="tytan652">
+     <name>tytan652</name>
+   </developer>
++  <developer_name>tytan652</developer_name>
+   <translation type="gettext">door-knocker</translation>
+ 
+   <screenshots>

--- a/xyz.tytanium.DoorKnocker.json
+++ b/xyz.tytanium.DoorKnocker.json
@@ -36,6 +36,10 @@
                     "url" : "https://codeberg.org/tytan652/door-knocker.git",
                     "tag": "0.4.2",
                     "commit": "470ff95d015091544726b5490c903a7ecd97f618"
+                },
+                {
+                    "type": "patch",
+                    "path": "fix_developer_name.patch"
                 }
             ]
         }


### PR DESCRIPTION
Appstream documentation marked it as deprecated but Flathub does not support its remplacement.